### PR TITLE
Allow importing label using name

### DIFF
--- a/gmailfilter/resource_gmailfilter_label.go
+++ b/gmailfilter/resource_gmailfilter_label.go
@@ -14,7 +14,25 @@ func resourceGmailfilterLabel() *schema.Resource {
 		Update: resourceGmailfilterLabelUpdate,
 		Delete: resourceGmailfilterLabelDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				config := meta.(*Config)
+				name := d.Id()
+
+				res, err := config.gmailService.Users.Labels.List(gmailUser).Do()
+				if err != nil {
+					return nil, handleNotFoundError(err, d, "Label")
+				}
+
+				for _, l := range res.Labels {
+					if l.Name == name {
+						d.SetId(l.Id)
+						d.Set("name", d.Id())
+						return []*schema.ResourceData{d}, nil
+					}
+				}
+
+				return nil, fmt.Errorf("no label with name=%q found", name)
+			},
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/gmailfilter/resource_gmailfilter_label.go
+++ b/gmailfilter/resource_gmailfilter_label.go
@@ -26,7 +26,6 @@ func resourceGmailfilterLabel() *schema.Resource {
 				for _, l := range res.Labels {
 					if l.Name == name {
 						d.SetId(l.Id)
-						d.Set("name", d.Id())
 						return []*schema.ResourceData{d}, nil
 					}
 				}

--- a/gmailfilter/resource_gmailfilter_label_test.go
+++ b/gmailfilter/resource_gmailfilter_label_test.go
@@ -45,6 +45,12 @@ func TestAccGmailFilterLabel_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "message_list_visibility", "show"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateId:     rand,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/website/docs/r/label.md
+++ b/website/docs/r/label.md
@@ -47,4 +47,10 @@ resource gmailfilter_label "sublabel" {
 * `type` - The owner type for the label. User labels are created by the user and can be modified and deleted by the user and can be applied to any message or thread. System labels are internally created and cannot be added, modified, or deleted. System labels may be able to be applied to or removed from messages and threads under some circumstances but this is not guaranteed. For example, users can apply and remove the `INBOX` and `UNREAD` labels from messages and threads, but cannot apply or remove the `DRAFTS` or `SENT` labels from messages or threads.
 
 
+## Import
 
+Label can be imported using `name`, e.g.
+
+```
+$ terraform import gmailfilter_label.label label1
+```


### PR DESCRIPTION
Thank you for this amazing provider!

I was looking for a way to import existing labels into my Terraform state. So far from what I understand from the source code I need to use the label id?

Since `data.gmailfilter_label` accepts `name` as argument, I wonder if you would accept a PR that allow importing label using label's name?

Let me know what you think about this. Thanks!