### PR TITLE
Fix disabled commands for workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Set up Go environemnt variables
         run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,14 +12,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Set up Go 1.14
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.14
-
-      - name: Set up Go environemnt variables
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,8 +14,8 @@ jobs:
 
       - name: Set up Go environemnt variables
         run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
 
       - name: Check out code into the Go module directory
@@ -37,8 +37,8 @@ jobs:
 
       - name: Set up Go environemnt variables
         run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
@@ -62,8 +62,8 @@ jobs:
 
       - name: Set up Go environemnt variables
         run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,15 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.14
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.14
-
-      - name: Set up Go environemnt variables
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-        shell: bash
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
@@ -31,14 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.14
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.14
-
-      - name: Set up Go environemnt variables
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
@@ -56,14 +45,9 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-18.04]
     steps:
       - name: Set up Go 1.14
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.14
-
-      - name: Set up Go environemnt variables
-        run: |
-          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1


### PR DESCRIPTION
close #8

This fixes #8:
- Update to use `$GITHUB_ENV` instead of `set-env`.
- Update to use `$GITHUB_PATH` instead of `add-path`.