### PR TITLE
Added -debug flag to enable debugging of providers

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,30 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/yamamoto-febc/terraform-provider-gmailfilter/gmailfilter"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: gmailfilter.Provider,
-	})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/yamamoto-febc/gmailfilter",
+			&plugin.ServeOpts{
+				ProviderFunc: gmailfilter.Provider,
+			})
+		if err != nil {
+			log.Println(err.Error())
+		}
+	} else {
+		plugin.Serve(&plugin.ServeOpts{
+			ProviderFunc: gmailfilter.Provider})
+	}
 }


### PR DESCRIPTION
Added `-debug` flag. This PR will allow developers to attach debuggers such as `delve`.

ref: https://www.terraform.io/docs/extend/guides/v2-upgrade-guide.html#support-for-debuggable-provider-binaries